### PR TITLE
Add `DatasourcePresenter`

### DIFF
--- a/examples/bells_and_whistles.yaml
+++ b/examples/bells_and_whistles.yaml
@@ -15,6 +15,8 @@ operators:
   type: dummy_operator
 
 presenters:
+- type: datasource_presenter
+  name: Data sources
 - type: coordinate_presenter
   name: Coordinates
 - type: proj_presenter

--- a/src/transformo/core.py
+++ b/src/transformo/core.py
@@ -49,7 +49,7 @@ class DataSource(pydantic.BaseModel):
 
         super().__init__(coordinates=coordinates, name=name, **kwargs)
 
-    def __add__(self, other) -> DataSource:
+    def __add__(self, other: DataSource) -> DataSource:
         """
         Add two `DataSource`s.
 
@@ -57,8 +57,18 @@ class DataSource(pydantic.BaseModel):
         joined together. The returned object is a generic `DataSource`,
         no matter what subclass of `DataSource` the two sources are created from.
         """
-        # new_coordinate_list = self.coordinates + other.coordinates
-        # return DataSource(coordinates=new_coordinate_list)
+        # if either of the two DataSource's are empty there's no need to add them
+        if not other.coordinates and self.coordinates:
+            return self
+
+        if not self.coordinates and other.coordinates:
+            return other
+
+        # if both are empty a single empty DataSource is returned
+        if not self.coordinates and not other.coordinates:
+            return DataSource(None)
+
+        # at this point both DataSources contain valid data and we can combine them
         return CombinedDataSource(self, other)
 
     def __hash__(self) -> int:

--- a/src/transformo/core.py
+++ b/src/transformo/core.py
@@ -381,7 +381,13 @@ class Presenter(pydantic.BaseModel):
         return tuple(set(subclasses))
 
     @abstractmethod
-    def evaluate(self, operators: list[Operator], results: list[DataSource]) -> None:
+    def evaluate(
+        self,
+        operators: list[Operator],
+        source_data: DataSource,
+        target_data: DataSource,
+        results: list[DataSource],
+    ) -> None:
         """
         Evaluate information from operators and resulting datasources and store in
         internal data container for use in program output.

--- a/src/transformo/datasources/__init__.py
+++ b/src/transformo/datasources/__init__.py
@@ -4,12 +4,13 @@ Transformo DataSource classes.
 
 from __future__ import annotations
 
-from transformo.core import DataSource
+from transformo.core import CombinedDataSource, DataSource
 
 from .bernese import BerneseCrdDataSource
 from .csv import CsvColumns, CsvDataSource
 
 __all__ = [
+    "CombinedDataSource",
     "DataSource",
     "CsvColumns",
     "CsvDataSource",

--- a/src/transformo/pipeline.py
+++ b/src/transformo/pipeline.py
@@ -71,7 +71,7 @@ class Pipeline(pydantic.BaseModel):
         self._combined_source_data = sum(self.source_data, DataSource(None))
         self._combined_target_data = sum(self.target_data, DataSource(None))
 
-        self._intermediate_results: list[DataSource] = [self._combined_source_data]
+        self._intermediate_results: list[DataSource] = []
 
     @classmethod
     def from_yaml(cls, yaml: str | bytes | bytearray) -> Pipeline:
@@ -110,7 +110,7 @@ class Pipeline(pydantic.BaseModel):
 
         TODO: Think of a better name.
         """
-        if len(self._intermediate_results) != len(self.operators) + 2:
+        if len(self._intermediate_results) != len(self.operators):
             self.process()
         return self._intermediate_results
 
@@ -157,10 +157,13 @@ class Pipeline(pydantic.BaseModel):
             )
             self._intermediate_results.append(current_step_datasource)
 
-        self._intermediate_results.append(self._combined_target_data)
-
         for presenter in self.presenters:
-            presenter.evaluate(operators=self.operators, results=self.results)
+            presenter.evaluate(
+                operators=self.operators,
+                source_data=self.all_source_data,
+                target_data=self.all_target_data,
+                results=self.results,
+            )
 
     def results_as_markdown(self) -> str:
         """

--- a/src/transformo/presenters/__init__.py
+++ b/src/transformo/presenters/__init__.py
@@ -76,6 +76,7 @@ from .coordinates import (
     ResidualPresenter,
     TopocentricResidualPresenter,
 )
+from .datasources import DatasourcePresenter
 from .proj import PROJPresenter
 
 __all__ = [
@@ -86,4 +87,5 @@ __all__ = [
     "ResidualPresenter",
     "TopocentricResidualPresenter",
     "CoordinateType",  # This might move elsewhere
+    "DatasourcePresenter",
 ]

--- a/src/transformo/presenters/__init__.py
+++ b/src/transformo/presenters/__init__.py
@@ -43,7 +43,13 @@ class DummyPresenter(Presenter):
 
     type: Literal["dummy_presenter"] = "dummy_presenter"
 
-    def evaluate(self, operators: list[Operator], results: list[DataSource]) -> None:
+    def evaluate(
+        self,
+        operators: list[Operator],
+        source_data: DataSource,
+        target_data: DataSource,
+        results: list[DataSource],
+    ) -> None:
         """
         Evaluate `results` created by `operators`.
         """

--- a/src/transformo/presenters/datasources.py
+++ b/src/transformo/presenters/datasources.py
@@ -1,0 +1,64 @@
+"""
+Presenters related to DataSource's.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Literal
+
+import yaml
+
+from transformo.core import DataSource, Operator, Presenter
+
+
+class DatasourcePresenter(Presenter):
+    """
+    Create lists of datasources used in a pipeline.
+    """
+
+    type: Literal["datasource_presenter"] = "datasource_presenter"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._data: dict[str, list] = {
+            "source_data": [],
+            "target_data": [],
+        }
+
+    def evaluate(
+        self,
+        operators: list[Operator],
+        source_data: DataSource,
+        target_data: DataSource,
+        results: list[DataSource],
+    ) -> None:
+        # for datasource in source_data.origins:
+        for datasource in source_data.origins:
+            self._data["source_data"].append(
+                datasource.model_dump(exclude_unset=True, mode="json")
+            )
+
+        for datasource in target_data.origins:
+            self._data["target_data"].append(
+                datasource.model_dump(exclude_unset=True, mode="json")
+            )
+
+    def as_json(self):
+        return json.dumps(self._data)
+
+    def as_markdown(self):
+        sources = yaml.dump(self._data["source_data"], sort_keys=False)
+        targets = yaml.dump(self._data["target_data"], sort_keys=False)
+
+        return f"""\
+### Source data
+```yaml
+{sources}
+```
+
+### Target data
+```yaml
+{targets}
+```
+"""

--- a/src/transformo/presenters/proj.py
+++ b/src/transformo/presenters/proj.py
@@ -26,7 +26,13 @@ class PROJPresenter(Presenter):
 
         self._output: dict[str, str] = {}
 
-    def evaluate(self, operators: list[Operator], results: list[DataSource]) -> None:
+    def evaluate(
+        self,
+        operators: list[Operator],
+        source_data: DataSource,
+        target_data: DataSource,
+        results: list[DataSource],
+    ) -> None:
         """
         Parse parameters from `operators`.
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,6 +12,7 @@ import pytest
 
 from transformo.datasources import CsvDataSource, DataSource
 from transformo.datatypes import Coordinate
+from transformo.operators import DummyOperator
 
 # pylint: disable=redefined-outer-name
 
@@ -125,3 +126,11 @@ def datasource(datasource_factory: Callable) -> DataSource:
     Datasource fixture.
     """
     return datasource_factory()
+
+
+@pytest.fixture()
+def dummy_operator() -> DummyOperator:
+    """
+    A dumb operator
+    """
+    return DummyOperator(name="Dummy")

--- a/test/datasources/test_datasource.py
+++ b/test/datasources/test_datasource.py
@@ -66,6 +66,29 @@ def test_datasource_update_coordinates(datasource: DataSource) -> None:
         datasource.update_coordinates(too_many_coordiantes)
 
 
+def test_datasource_sum(datasource_factory: DataSource) -> None:
+    """
+    Test DataSource.__sum__
+
+    In particular the edge cases where at least one empty DataSource is part
+    of the summation.
+    """
+
+    ds1 = datasource_factory()
+    ds2 = datasource_factory()
+
+    none_sum = DataSource(None) + DataSource(None)
+    assert not none_sum.coordinates
+
+    assert ds1 + DataSource(None) is ds1
+    assert DataSource(None) + ds1 is ds1
+
+    sum_ds = ds1 + ds2
+
+    assert isinstance(sum_ds, CombinedDataSource)
+    assert len(sum_ds.coordinates) == len(ds1.coordinates) + len(ds2.coordinates)
+
+
 def test_combineddatasource(datasource_factory: DataSource) -> None:
     """
     Test mechanincs of CombinedDataSource.

--- a/test/presenters/test_coordinates.py
+++ b/test/presenters/test_coordinates.py
@@ -14,7 +14,7 @@ from transformo.presenters import (
 )
 
 
-def test_coordinate_presenter(files):
+def test_coordinate_presenter(files, dummy_operator):
     """
     .
     """
@@ -23,22 +23,41 @@ def test_coordinate_presenter(files):
     ds1 = CsvDataSource(filename=files["dk_cors_itrf2014.csv"])
     ds2 = CsvDataSource(filename=files["dk_cors_etrs89.csv"])
 
-    p.evaluate(operators=[], results=[ds1, ds2])
+    p.evaluate(
+        operators=[dummy_operator],
+        source_data=ds1,
+        target_data=ds2,
+        results=[ds1],  # emmulate the dummy operator
+    )
     results = json.loads(p.as_json())
 
     # A few sanity checks of the JSON data
-    print(results)
-    assert results[0]["BUDP"][0] == ds1.coordinates[0].x
-    assert results[1]["BUDP"][0] == ds2.coordinates[0].x
+    assert results[1]["BUDP"][0] == ds1.coordinates[0].x
+    assert results[2]["BUDP"][0] == ds2.coordinates[0].x
 
-    assert results[0]["FYHA"][2] == ds1.coordinates[3].z
-    assert results[1]["FYHA"][2] == ds2.coordinates[3].z
+    assert results[1]["FYHA"][2] == ds1.coordinates[3].z
+    assert results[2]["FYHA"][2] == ds2.coordinates[3].z
 
     # Really just here to detect regressions
     expected_text = """
 Source and target coordinates as well as intermediate results shown in tabular form.
 
 ### Source coordinates
+
+|Station|      x       |      y      |      z       |     t     |
+|-------|--------------|-------------|--------------|-----------|
+| BUDP  | 3513637.9742 | 778956.6653 | 5248216.5981 | 2022.9301 |
+| ESBC  | 3582104.7300 | 532590.2159 | 5232755.1625 | 2022.9301 |
+| FER5  | 3491111.1770 | 497995.1232 | 5296843.0503 | 2022.9301 |
+| FYHA  | 3611639.4845 | 635936.6595 | 5201015.0137 | 2022.9301 |
+| GESR  | 3625387.0268 | 765504.4193 | 5174102.8643 | 2022.9301 |
+| HABY  | 3507446.6753 | 704379.4346 | 5262740.4338 | 2022.9301 |
+| HIRS  | 3374902.7677 | 593115.8340 | 5361509.6764 | 2022.9301 |
+| SMID  | 3557910.9582 | 599176.9512 | 5242066.6105 | 2022.9301 |
+| SULD  | 3446393.9399 | 591713.4041 | 5316383.6189 | 2022.9301 |
+| TEJH  | 3522394.9133 | 933244.9595 | 5217231.6164 | 2022.9301 |
+
+### Step 1: DummyOperator()
 
 |Station|      x       |      y      |      z       |     t     |
 |-------|--------------|-------------|--------------|-----------|
@@ -73,7 +92,7 @@ Source and target coordinates as well as intermediate results shown in tabular f
     assert expected_text == p.as_markdown()
 
 
-def test_residual_presenter():
+def test_residual_presenter(dummy_operator):
     """
     Test the residual presenter.
     """
@@ -93,7 +112,12 @@ def test_residual_presenter():
     )
 
     presenter = ResidualPresenter()
-    presenter.evaluate(operators=[], results=[model, target])
+    presenter.evaluate(
+        operators=[dummy_operator],
+        source_data=model,
+        target_data=target,
+        results=[model],
+    )
 
     data = json.loads(presenter.as_json())
 
@@ -104,7 +128,7 @@ def test_residual_presenter():
     print(presenter.as_markdown())
 
 
-def test_topocentricresidual_presenter_degree():
+def test_topocentricresidual_presenter_degree(dummy_operator):
     """
     Test the topocentric residual presenter using coordinate type degrees.
     """
@@ -123,4 +147,9 @@ def test_topocentricresidual_presenter_degree():
     )
 
     presenter = TopocentricResidualPresenter(coordinate_type=CoordinateType.DEGREES)
-    presenter.evaluate(operators=[], results=[model, target])
+    presenter.evaluate(
+        operators=[],
+        source_data=model,
+        target_data=target,
+        results=[model],
+    )

--- a/test/presenters/test_datasources.py
+++ b/test/presenters/test_datasources.py
@@ -1,0 +1,36 @@
+"""
+Tests for DataSourcePresenter.
+"""
+
+import json
+
+from transformo.datasources import BerneseCrdDataSource, CsvDataSource
+from transformo.presenters import DatasourcePresenter
+
+
+def test_datasource_presenter(files) -> None:
+    """
+    Simple sanity tests for the DatasourcePresenter.
+    """
+    P = DatasourcePresenter(name="Data sources")
+
+    P.evaluate(
+        operators=[],
+        source_data=BerneseCrdDataSource(
+            name="bernie", filename=files["dk_bernese54.CRD"]
+        ),
+        target_data=CsvDataSource(
+            name="commas", filename=files["dk_cors_itrf2014.csv"]
+        ),
+        results=[],
+    )
+
+    presenter_json = json.loads(P.as_json())
+
+    assert "source_data" in presenter_json.keys()
+    assert "target_data" in presenter_json.keys()
+    assert presenter_json["source_data"][0]["name"] == "bernie"
+    assert presenter_json["target_data"][0]["name"] == "commas"
+
+    markdown = P.as_markdown()
+    assert markdown.splitlines()[0] == "### Source data"

--- a/test/presenters/test_proj.py
+++ b/test/presenters/test_proj.py
@@ -21,17 +21,30 @@ def test_proj_presenter():
     )
 
     presenter_with_no_operators = PROJPresenter()
-    presenter_with_no_operators.evaluate(operators=[], results=[])
+    presenter_with_no_operators.evaluate(
+        operators=[],
+        source_data=None,
+        target_data=None,
+        results=[],
+    )
 
     assert presenter_with_no_operators.as_json() == '{"projstring": "+proj=noop"}'
 
     presenter_with_one_operator = PROJPresenter()
-    presenter_with_one_operator.evaluate(operators=[helmert], results=[])
+    presenter_with_one_operator.evaluate(
+        operators=[helmert],
+        source_data=None,
+        target_data=None,
+        results=[],
+    )
     assert presenter_with_one_operator.as_json() == '{"projstring": "+proj=noop"}'
 
     presenter_with_several_operators = PROJPresenter()
     presenter_with_several_operators.evaluate(
-        operators=[dummy, helmert_with_one_params, helmert_with_params], results=[]
+        operators=[dummy, helmert_with_one_params, helmert_with_params],
+        source_data=None,
+        target_data=None,
+        results=[],
     )
 
     expected_pipeline = (
@@ -66,6 +79,8 @@ Transformation parameters given as a [PROJ](https://proj.org/) string.
             helmert_with_params,
             proj_with_pipeline,
         ],
+        source_data=None,
+        target_data=None,
         results=[],
     )
     expected_pipeline = (

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -147,21 +147,28 @@ def test_pipeline_access() -> None:
 
     pipeline.process()
 
-    # check expected residuals
     results = pipeline.results
+    source = pipeline.all_source_data
+    target = pipeline.all_target_data
+
+    # check expected residuals
+    assert len(results) == 2  # we have added two operators to the pipeline
+
     # difference from source to step one - we expect a y-offset of 150 m,
     # as specified with the given parameter for `helmert_transformation`
-    assert results[1].coordinates[0].x - results[0].coordinates[0].x == 0
-    assert results[1].coordinates[0].y - results[0].coordinates[0].y == 150
-    assert results[1].coordinates[0].z - results[0].coordinates[0].z == 0
+    assert results[0].coordinates[0].x - source.coordinates[0].x == 0
+    assert results[0].coordinates[0].y - source.coordinates[0].y == 150
+    assert results[0].coordinates[0].z - source.coordinates[0].z == 0
+
     # difference between step two and one
-    assert results[2].coordinates[0].x - results[1].coordinates[0].x == 10
-    assert results[2].coordinates[0].y - results[1].coordinates[0].y == 50
-    assert results[2].coordinates[0].z - results[1].coordinates[0].z == 3000
+    assert results[1].coordinates[0].x - results[0].coordinates[0].x == 10
+    assert results[1].coordinates[0].y - results[0].coordinates[0].y == 50
+    assert results[1].coordinates[0].z - results[0].coordinates[0].z == 3000
+
     # difference between step two and target coordinates
-    assert results[3].coordinates[0].x - results[2].coordinates[0].x == 0
-    assert results[3].coordinates[0].y - results[2].coordinates[0].y == 0
-    assert results[3].coordinates[0].z - results[2].coordinates[0].z == 0
+    assert target.coordinates[0].x - results[1].coordinates[0].x == 0
+    assert target.coordinates[0].y - results[1].coordinates[0].y == 0
+    assert target.coordinates[0].z - results[1].coordinates[0].z == 0
 
 
 def test_pipeline_results_as_markdown(files: dict) -> None:


### PR DESCRIPTION
The first two commits in this PR provides refactoring that enables development of the `DatasourcePresenter`. A minor bug is fixed in the third and the fourth commits is the actual implementation of the `DatasourcePresenter`.

Example:

```sh
$ cat pipeline.yaml
source_data:
- name: ITRF2014
  type: csv
  filename: test/data/dk_cors_itrf2014.csv
  columns: [station, t, y, z, x, sz, sy, sx, weight]

- name: ITRF2014 repeated
  type: csv
  filename: test/data/dk_cors_itrf2014.csv

- name: ITRF2014-2
  type: csv
  filename: test/data/dk_cors_itrf2014.csv

- name: Coordinates determined using Bernes 5.2
  type: bernese_crd
  filename: test/data/dk_bernese52.crd
  discard_flags: [W]

target_data:
- name: ETRS89
  type: csv
  filename: test/data/dk_cors_etrs89.csv

operators:
- type: dummy_operator

presenters:
- name: Datasources
  type: datasource_presenter

$ transformo pipeline.yaml --report-in-terminal
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃                              Transformo Results                              ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

Created with Transformo version 0.1.0, 2025-02-10 21:19:09.851573.              


                                  Datasources                                   

                                  Source data                                   

                                                                                
 - type: csv                                                                    
   name: ITRF2014-2                                                             
   filename: test/data/dk_cors_itrf2014.csv                                     
 - type: bernese_crd                                                            
   name: Coordinates determined using Bernes 5.2                                
   filename: test/data/dk_bernese52.crd                                         
   discard_flags:                                                               
   - W                                                                          
 - type: csv                                                                    
   name: ITRF2014                                                               
   filename: test/data/dk_cors_itrf2014.csv                                     
   columns:                                                                     
   - station                                                                    
   - t                                                                          
   - y                                                                          
   - z                                                                          
   - x                                                                          
   - sz                                                                         
   - sy                                                                         
   - sx                                                                         
   - weight                                                                     
 - type: csv                                                                    
   name: ITRF2014 repeated                                                      
   filename: test/data/dk_cors_itrf2014.csv                                     
                                                                                

                                  Target data                                   

                                                                                
 - type: csv                                                                    
   name: ETRS89                                                                 
   filename: test/data/dk_cors_etrs89.csv                                       
                                                                                
```