### PR TITLE
Add options for writing JSON and GeoJSON files

### DIFF
--- a/src/cli/entries.py
+++ b/src/cli/entries.py
@@ -116,7 +116,7 @@ def main(  # pylint: disable=too-many-arguments
         # error output presented to the user, so pylint's good advice about
         # re-raising the exceptions are not applicable here.
         except FileNotFoundError as error:
-            logger.error(f"File not found: {error.filename}")
+            logger.error(f"File or directory not found: {error.filename}")
             raise SystemExit(1)
 
         except ValidationError as error:

--- a/src/transformo/_typing.py
+++ b/src/transformo/_typing.py
@@ -6,7 +6,8 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal, Protocol
+from os import PathLike
+from typing import Annotated, Any, Literal, Protocol, runtime_checkable
 
 import numpy as np
 import numpy.typing as npt
@@ -92,3 +93,24 @@ class PresenterLike(Protocol):
         Store parsed information from operators and resulting datasources in
         internal data container for further processing.
         """
+
+
+@runtime_checkable
+class JSONFileCreator(Protocol):
+    """
+    Presenter's implementing this protocol can create a JSON-file.
+
+    If a class implements this protocol, an attempt at creating a JSON file
+    will be made during the Pipeline processing, after evaluating the
+    Presenter's.
+
+    When implementing a JSONFileCreator, it should be checked in __init__()
+    if `json_file` can be created. This will make the pipeline serializer fail
+    when the file can't be created. In most cases this will be because the path
+    includes a directory that doesn't exists.
+    """
+
+    json_file: PathLike | None
+
+    def create_json_file(self) -> None:
+        """Create a JSON-file."""

--- a/src/transformo/_typing.py
+++ b/src/transformo/_typing.py
@@ -114,3 +114,24 @@ class JSONFileCreator(Protocol):
 
     def create_json_file(self) -> None:
         """Create a JSON-file."""
+
+
+@runtime_checkable
+class GeoJSONFileCreator(Protocol):
+    """
+    Presenter's implementing this protocol can create a GeoJSON-file.
+
+    If a class implements this protocol, an attempt at creating a GeoJSON file
+    will be made during the Pipeline processing, after evaluating the
+    Presenter's.
+
+    When implementing a GeoJSONFileCreator, it should be checked in __init__()
+    if `geojson_file` can be created. This will make the pipeline serializer
+    fail when the file can't be created. In most cases this will be because
+    the path includes a directory that doesn't exists.
+    """
+
+    geojson_file: PathLike | None
+
+    def create_geojson_file(self) -> None:
+        """Create a GeoJSON-file."""

--- a/src/transformo/datatypes.py
+++ b/src/transformo/datatypes.py
@@ -86,6 +86,32 @@ class Coordinate:  # pylint: disable=too-many-instance-attributes
 
         return np.multiply(weights, self.w)
 
+    def geojson_feature(self, properties: dict | None = None) -> dict:
+        """
+        Return a basic GeoJSON feature.
+
+        The feature is composed of the station coordinates and name. Additional
+        properties can be added by supplying them in the `properties` dict.
+        """
+        feat: dict = {
+            "type": "Feature",
+            "properties": {
+                "station": self.station,
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    self.x,
+                    self.y,
+                ],
+            },
+        }
+
+        if properties:
+            feat["properties"] = feat["properties"] | properties
+
+        return feat
+
 
 class Parameter:
     """

--- a/src/transformo/pipeline.py
+++ b/src/transformo/pipeline.py
@@ -22,6 +22,7 @@ import transformo.presenters
 from transformo._typing import (
     CoordinateMatrix,
     DataSourceLike,
+    GeoJSONFileCreator,
     JSONFileCreator,
     OperatorLike,
     PresenterLike,
@@ -168,6 +169,9 @@ class Pipeline(pydantic.BaseModel):
 
             if isinstance(presenter, JSONFileCreator):
                 presenter.create_json_file()
+
+            if isinstance(presenter, GeoJSONFileCreator):
+                presenter.create_geojson_file()
 
     def results_as_markdown(self) -> str:
         """

--- a/src/transformo/pipeline.py
+++ b/src/transformo/pipeline.py
@@ -22,6 +22,7 @@ import transformo.presenters
 from transformo._typing import (
     CoordinateMatrix,
     DataSourceLike,
+    JSONFileCreator,
     OperatorLike,
     PresenterLike,
 )
@@ -164,6 +165,9 @@ class Pipeline(pydantic.BaseModel):
                 target_data=self.all_target_data,
                 results=self.results,
             )
+
+            if isinstance(presenter, JSONFileCreator):
+                presenter.create_json_file()
 
     def results_as_markdown(self) -> str:
         """

--- a/src/transformo/presenters/coordinates.py
+++ b/src/transformo/presenters/coordinates.py
@@ -5,6 +5,7 @@ Presenters related to coordinates.
 from __future__ import annotations
 
 import json
+import pathlib
 from enum import Enum
 from typing import Literal
 
@@ -16,12 +17,23 @@ from transformo.core import DataSource, Operator, Presenter, Transformer
 from . import construct_markdown_table
 
 
+def _raise_exception_if_file_cant_be_created(filename: pathlib.Path):
+    """Throws a FileNotFoundError if the file can't be opened"""
+    try:
+        with open(filename, "w", encoding="utf-8") as f:
+            f.write("")
+    finally:
+        if filename.exists():
+            filename.unlink()
+
+
 class CoordinatePresenter(Presenter):
     """
     Create lists of coordinates for all stages of a pipeline.
     """
 
     type: Literal["coordinate_presenter"] = "coordinate_presenter"
+    json_file: pathlib.Path | None = None
 
     def __init__(self, **kwargs) -> None:
         """."""
@@ -29,6 +41,9 @@ class CoordinatePresenter(Presenter):
 
         self._operator_titles: list[str] = []
         self._steps: list[dict[str, list[float | None]]] = []
+
+        if self.json_file:
+            _raise_exception_if_file_cant_be_created(self.json_file)
 
     def evaluate(
         self,
@@ -67,6 +82,14 @@ class CoordinatePresenter(Presenter):
     def as_json(self) -> str:
         return json.dumps(self._steps)
 
+    def create_json_file(self) -> None:
+        """Output data as a JSON-file"""
+        if not self.json_file:
+            return None
+
+        with open(self.json_file, "w", encoding="utf-8") as f:
+            json.dump(self._steps, f)
+
     def as_markdown(self) -> str:
         fmt = ".4f"
         header = ["Station", "x", "y", "z", "t"]
@@ -101,10 +124,14 @@ class ResidualPresenter(Presenter):
     """
 
     type: Literal["residual_presenter"] = "residual_presenter"
+    json_file: pathlib.Path | None = None
 
     def __init__(self, **kwargs) -> None:
         """."""
         super().__init__(**kwargs)
+
+        if self.json_file:
+            _raise_exception_if_file_cant_be_created(self.json_file)
 
         self._data: dict = {}
 
@@ -140,6 +167,14 @@ class ResidualPresenter(Presenter):
 
     def as_json(self) -> str:
         return json.dumps(self._data)
+
+    def create_json_file(self) -> None:
+        """Output data as a JSON-file"""
+        if not self.json_file:
+            return None
+
+        with open(self.json_file, "w", encoding="utf-8") as f:
+            json.dump(self._data, f)
 
     def as_markdown(self) -> str:
         fmt = "< 10.3g"  # three significant figures, could potentially be an option
@@ -205,10 +240,14 @@ class TopocentricResidualPresenter(Presenter):
     type: Literal["topocentricresidual_presenter"] = "topocentricresidual_presenter"
 
     coordinate_type: CoordinateType
+    json_file: pathlib.Path | None = None
 
     def __init__(self, coordinate_type: CoordinateType, **kwargs) -> None:
         """."""
         super().__init__(coordinate_type=coordinate_type, **kwargs)
+
+        if self.json_file:
+            _raise_exception_if_file_cant_be_created(self.json_file)
 
         self._data: dict = {}
 
@@ -275,6 +314,14 @@ class TopocentricResidualPresenter(Presenter):
 
     def as_json(self) -> str:
         return json.dumps(self._data)
+
+    def create_json_file(self) -> None:
+        """Output data as a JSON-file"""
+        if not self.json_file:
+            return None
+
+        with open(self.json_file, "w", encoding="utf-8") as f:
+            json.dump(self._data, f)
 
     def as_markdown(self) -> str:
         # TODO: Rewrite help text

--- a/src/transformo/presenters/coordinates.py
+++ b/src/transformo/presenters/coordinates.py
@@ -329,7 +329,7 @@ class TopocentricResidualPresenter(Presenter):
 
         fmt = "< 10.3g"  # three significant figures, could potentially be an option
 
-        header = ["Station", "North", "East", "Up", "2D residual", "3D residual"]
+        header = ["Station", "North", "East", "Up", "Planar residual", "Total residual"]
         rows = []
         for station, residuals in self._data["residuals"].items():
             row = [station, *[format(r, fmt) for r in residuals]]
@@ -337,16 +337,17 @@ class TopocentricResidualPresenter(Presenter):
 
         text = (
             "### Station coordinate residuals\n\n"
-            "Residuals of the modelled coordinates as compared to "
-            "target cooordinates. The table contains simple "
+            "Residuals in topocentric space of the modelled coordinates as "
+            "compared to target cooordinates. The table contains coordinate "
             "differences of the individual coordinate components "
-            "as well as the length (norm) of the residual vector.\n\n"
+            "as well as the length (norm) of the residual vector, "
+            "both in the plane and across all dimensions.\n\n"
         )
         text += construct_markdown_table(header, rows)
 
         text += "\n\n### Residual statistics\n"
 
-        header = ["Measure", "Rx", "Ry", "Rz", "2D norm", "3D norm"]
+        header = ["Measure", "North", "East", "Up", "Planar residual", "Total residual"]
         rows = []
         for measure, values in self._data["stats"].items():
             row = [measure, *[format(v, fmt) for v in values]]

--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -82,6 +82,37 @@ def test_coordinate_weights_property(coordinate: Coordinate):
     assert isinstance(coordinate.weights, np.ndarray)
 
 
+def test_coordinate_geojson_feature(coordinate: Coordinate):
+    """Test geojson_feature returns valid GeoJSON features."""
+
+    feature = coordinate.geojson_feature()
+
+    print(feature)
+
+    assert feature["geometry"]["coordinates"][0] == coordinate.x
+    assert feature["geometry"]["coordinates"][1] == coordinate.y
+    assert feature["properties"]["station"] == coordinate.station
+
+    # Check that adding auxillary properties works
+    feature_with_properties = coordinate.geojson_feature(
+        properties={
+            "E": 12.3,
+            "N": 4.32,
+            "U": 6.23,
+            "attribute": "value",
+            "station": "STATION",
+        }
+    )
+
+    assert feature_with_properties["properties"]["E"] == 12.3
+    assert feature_with_properties["properties"]["N"] == 4.32
+    assert feature_with_properties["properties"]["U"] == 6.23
+    assert feature_with_properties["properties"]["attribute"] == "value"
+
+    # verify that origin properties are overriden by those in `properties`
+    assert feature_with_properties["properties"]["station"] == "STATION"
+
+
 def test_parameter():
     """Test functionality of Parameter"""
 


### PR DESCRIPTION
Some presenters now have the option of saving it's results as both JSON and GeoJSON files for further analysis is other software.

The functionality is added to `CoordinatePresenter`, `ResidualPresenter` and `TopocentricResidualPresenter` for now. 

Below is an example of a pipeline setup that show-cases the new features:

```yaml
source_data:
- name: ITRF2014
  type: csv
  filename: C:\dev\transformo\test\data\dk_cors_itrf2014.csv
target_data:
- name: ETRS89
  type: csv
  filename: C:\dev\transformo\test\data\dk_cors_etrs89.csv
operators:
- name: null
  type: dummy_operator
presenters:
- type: coordinate_presenter
  name: Coordinates
  geojson_file: coordinates.geojson
  json_file: coordinates.json
- name: Residuals
  type: residual_presenter
  geojson_file: residuals.geojson
- name: Topocentric residual
  type: topocentricresidual_presenter
  coordinate_type: cartesian
  geojson_file: enu_residuals.geojson
```