### PR TITLE
Add possibility to run commands before and after a pipeline

### DIFF
--- a/examples/process_commands.yaml
+++ b/examples/process_commands.yaml
@@ -1,0 +1,36 @@
+# Demonstrate the use of the pre- and post-processing commands.
+# Any command that is available in the system PATH should be
+# possible to execute through Transformo. This example mainly
+# shows the syntax of this feature set but in a production
+# setting it could be used to prepare data before using it as
+# datasources or perhaps plotting statitics in a post-processing
+# command based on the output of a Presenter.
+#
+# Note that output the processing commands is withheld unless
+# Transformo is called with the `-v` flag that increases verbosity.
+
+pre_processing_commands:
+  - echo This command is process before the pipeline.
+
+source_data:
+- name: Coordinates determined using Bernes 5.2
+  type: bernese_crd
+  filename: test/data/dk_bernese52.crd
+  discard_flags: [W] # Flags are given as a list. Flags are separated by commas.
+
+target_data:
+- name: Coordinates determined using Bernes 5.4
+  type: bernese_crd
+  filename: test/data/dk_bernese54.crd
+  discard_flags: [W]
+
+operators:
+- name: null
+  type: dummy_operator
+
+presenters:
+- type: dummy_presenter
+
+post_processing_commands:
+  - echo This command is processed after the pipeline.
+  - echo So is this one.

--- a/src/transformo/__init__.py
+++ b/src/transformo/__init__.py
@@ -4,13 +4,59 @@ Transformo - The general purpose tool for determining geodetic transformations
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 __version__ = "0.1.0"
-
 
 # Logging
 console_handler = logging.StreamHandler()
 logger = logging.getLogger(__name__)
 logger.addHandler(console_handler)
 logger.setLevel(logging.WARNING)
+
+
+# The functions below are all related to running shell commands. It may
+# seem overly complicated but there does not seem to be a simpler way to
+# capture the STDOUT and STDERR seperately.
+
+
+async def _log_warning(stream):
+    while not stream.at_eof():
+        data = await stream.readline()
+        line = data.decode("ascii").rstrip()
+        logger.warning(line)
+
+
+async def _log_error(stream):
+    while not stream.at_eof():
+        data = await stream.readline()
+        line = data.decode("ascii").rstrip()
+        logger.error(line)
+
+
+async def _execute(command, *argument):
+    proc = await asyncio.create_subprocess_exec(
+        command,
+        *argument,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    tasks = [
+        asyncio.create_task(_log_warning(proc.stdout)),
+        asyncio.create_task(_log_error(proc.stderr)),
+        asyncio.create_task(proc.wait()),
+    ]
+    await asyncio.wait(tasks)
+
+    return proc.returncode
+
+
+def run_command(command: str):
+    """Run a command.
+
+    Stdout and stderr utput of command is logged at WARNING and ERROR
+    levels respectively.
+    """
+    cmd = command.split()
+    asyncio.run(_execute(cmd[0], *cmd[1:]))

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -219,3 +219,25 @@ def test_pipeline_results_as_json(files: dict) -> None:
 
     assert "PROJ" in data.keys()
     assert "Coordinates" in data.keys()
+
+
+def test_pipeline_processing_commands(caplog, datasource: DataSource) -> None:
+    """
+    Test the use of pre- and post-processing commands in a Pipeline.
+    """
+    pipeline = Pipeline(
+        source_data=[datasource],
+        target_data=[datasource],
+        operators=[DummyOperator()],
+        presenters=[DummyPresenter()],
+        pre_processing_commands=["echo pre-process", "python --version"],
+        post_processing_commands=["echo post-process 1", "echo post-process 2"],
+    )
+
+    pipeline.process()
+
+    log_captures = [msg for (_, _, msg) in caplog.record_tuples]
+
+    assert "pre-process" in log_captures
+    assert "post-process 1" in log_captures
+    assert "post-process 2" in log_captures


### PR DESCRIPTION
Any shell-command should be possible to run this way as pre- or post-processing steps for the pipeline. One idea with this is to be able to prepare input data using ouput of a different software package or to create figures based on the output of the pipeline.