### PR TITLE
DataSource overrides

### DIFF
--- a/examples/bernese_crd_files.yaml
+++ b/examples/bernese_crd_files.yaml
@@ -8,18 +8,25 @@ source_data:
   type: bernese_crd
   filename: test/data/dk_bernese52.crd
   discard_flags: [W] # Flags are given as a list. Flags are separated by commas.
+  sx: 0.05
+  sy: 0.05
+  sz: 0.1
 
 target_data:
 - name: Coordinates determined using Bernes 5.4
   type: bernese_crd
   filename: test/data/dk_bernese54.crd
   discard_flags: [W]
+  sx: 0.02
+  sy: 0.02
+  sz: 0.04
 
 operators:
 - name: null
-  type: dummy_operator
+  type: helmert_translation
 
 presenters:
 - type: coordinate_presenter
 - type: topocentricresidual_presenter
   coordinate_type: cartesian
+- type: proj_presenter

--- a/examples/datasource_overrides.yaml
+++ b/examples/datasource_overrides.yaml
@@ -1,0 +1,60 @@
+# Demonstrate how to modify the data read from a data source.
+#
+# Data can be overridden in two ways:
+#
+#   1. for the entire datasource
+#   2. on a station basis
+#
+# The following fields can be changed for entirety of a data source:
+#
+#   t, sx, sy, sz, w
+#
+# This gives the opportunity to change weighting of coordinates across
+# the whole data source, as well as adjust the epoch in case it is not
+# registered correctly in the original source data.
+#
+# Similarly, coordinate data can be adjusted at a station level. Here
+# all aspects of a coordinate can be changed. The available fields are:
+#
+#   station, t, x, y, z, sx, sy, sz, w
+#
+# This is useful in case the source data has errors in it or if it would
+# be helpful to weigth a particular station differently that the rest.
+
+source_data:
+- name: ITRF2014
+  type: csv
+  filename: test/data/dk_cors_itrf2014.csv
+
+  # changes across the whole data source
+  sx: 0.02
+  sy: 0.02
+  sz: 0.04
+  w: 0.8
+  t: 2019.32
+
+  # changes to data from specific stations
+  overrides:
+    BUDP:
+      sz: 0.03
+      w: 1.0
+      t: 2099.0
+
+target_data:
+- name: ETRS89
+  type: csv
+  filename: test/data/dk_cors_etrs89.csv
+
+  # changes to data from specific stations
+  overrides:
+    FYHA:
+      t: 3333.0
+    HIRS:
+      station: XXXX
+
+operators:
+- name: Helmert 3 Parameter Estimation
+  type: helmert_translation
+
+presenters:
+- type: coordinate_presenter

--- a/src/transformo/core.py
+++ b/src/transformo/core.py
@@ -17,6 +17,40 @@ from transformo._typing import CoordinateMatrix, Vector
 from transformo.datatypes import Coordinate, Parameter
 
 
+@pydantic.dataclasses.dataclass()
+class CoordinateOverrides:
+    """
+    Helper dataclass, that enables overriding coordinate values in a DataSource.
+
+    The fields in this class are the same as the fields of Coordinate, with the
+    exception that none of the fields are required and their default values are
+    set to None.
+
+    If the definitions are changed here, they need to be changed in Coordinate
+    as well.
+    """
+
+    # station name
+    station: str | None = pydantic.Field(None, pattern="[A-z0-9].*", strict=True)
+
+    # spatial coordinate elements
+    x: float | None = pydantic.Field(None, allow_inf_nan=False, strict=True)
+    y: float | None = pydantic.Field(None, allow_inf_nan=False, strict=True)
+    z: float | None = pydantic.Field(None, allow_inf_nan=False, strict=True)
+
+    sx: float | None = pydantic.Field(None, ge=0.0, allow_inf_nan=False, strict=True)
+    sy: float | None = pydantic.Field(None, ge=0.0, allow_inf_nan=False, strict=True)
+    sz: float | None = pydantic.Field(None, ge=0.0, allow_inf_nan=False, strict=True)
+
+    # coordinate weight
+    w: float | None = pydantic.Field(None, ge=0.0, allow_inf_nan=False, strict=True)
+
+    # coordinate epoch
+    t: float | None = pydantic.Field(
+        None, ge=0.0, le=10000.0, allow_inf_nan=False, strict=True
+    )
+
+
 class DataSource(pydantic.BaseModel):
     """Base class for any Transformo data source."""
 
@@ -46,13 +80,19 @@ class DataSource(pydantic.BaseModel):
         None, ge=0.0, le=10000.0, allow_inf_nan=False, strict=True
     )
 
+    # station-based overrides
+    overrides: dict[str, CoordinateOverrides] | None = pydantic.Field(
+        default_factory=dict
+    )
+
     # coordinates are not included in pipeline serialization
     coordinates: list[Coordinate] = pydantic.Field(default_factory=list, exclude=True)
 
     def __init__(
         self,
-        coordinates: list[Coordinate] | None = None,
         name: str | None = None,
+        coordinates: list[Coordinate] | None = None,
+        overrides: dict[str, CoordinateOverrides] | None = None,
         **kwargs,
     ) -> None:
         """Set up base reader."""
@@ -60,7 +100,12 @@ class DataSource(pydantic.BaseModel):
             # it's not kosher to initialize a value with [] as default
             coordinates = []
 
-        super().__init__(coordinates=coordinates, name=name, **kwargs)
+        if overrides is None:
+            overrides = {}
+
+        super().__init__(
+            name=name, coordinates=coordinates, overrides=overrides, **kwargs
+        )
 
         # See the comment below regarding post initialization.
         # Execute post initialization if, and only if, self is a DataSource.
@@ -100,7 +145,6 @@ class DataSource(pydantic.BaseModel):
 
         cls.__init__ = init_decorator(cls.__init__)
 
-    # def model_post_init(self, __context: Any) -> None:
     def __post_init__(self) -> None:
         """
         Modify DataSource after the initial creation.
@@ -108,27 +152,67 @@ class DataSource(pydantic.BaseModel):
         This allow overrides of the original data, for instance by setting
         a different standard deviation of the coordinates in the DataSource.
 
-        Additionally, station-based overrides can be handled here.
+        Additionally, station-based overrides are handled here.
 
         Do not override this method without calling super().__post_init__().
         Or better yet, do not override it at all.
         """
+        # pylint: disable=unsubscriptable-object
 
         for c in self.coordinates:
-            if self.sx:
+            if self.sx is not None:
                 c.sx = self.sx
 
-            if self.sy:
+            if self.sy is not None:
                 c.sy = self.sy
 
-            if self.sz:
+            if self.sz is not None:
                 c.sz = self.sz
 
-            if self.w:
+            if self.w is not None:
                 c.w = self.w
 
             if self.t is not None:
                 c.t = self.t
+
+            if self.overrides is None:
+                continue
+
+            if c.station in self.overrides.keys():
+                # We store the original station name in key to avoid KeyError's
+                # when overriding the station name. If c.station is used as the
+                # key it will be overwritten in case a station is renamed in the
+                # overrides.
+                key = c.station
+
+                # The use of the walrus operator here might look a bit
+                # unnecessary, but it avoids a mypy incompatible type error
+                if (station := self.overrides[key].station) is not None:
+                    c.station = station
+
+                if (x := self.overrides[key].x) is not None:
+                    c.x = x
+
+                if (y := self.overrides[key].y) is not None:
+                    c.y = y
+
+                if (z := self.overrides[key].z) is not None:
+                    c.z = z
+
+                if (sx := self.overrides[key].sx) is not None:
+                    c.sx = sx
+
+                if (sy := self.overrides[key].sy) is not None:
+                    c.sy = sy
+
+                if (sz := self.overrides[key].sz) is not None:
+                    c.sz = sz
+
+                if (w := self.overrides[key].w) is not None:
+                    c.w = w
+
+                if (t := self.overrides[key].t) is not None:
+                    c.t = t
 
     def __add__(self, other: DataSource) -> DataSource:
         """

--- a/src/transformo/datasources/bernese.py
+++ b/src/transformo/datasources/bernese.py
@@ -93,11 +93,12 @@ class BerneseCrdDataSource(DataSource):
     Parse data from a Bernese CRD-file.
 
     CRD-files do not have any information about the uncertainties of the
-    coordinates. A file-wide uncertainty can be set using the field "stddev".
-    If "stddev" is not set the value 0.0 is used.
+    coordinates. By default they are set to 0.0. This can be overridden
+    by setting the fields `sx`, `sy` and `sz` respectively.
 
     Weights aren't specified in the file either and are set to 1.0 for all
-    coordinates in the file.
+    coordinates in the file. This can be overriden by setting the field
+    `w`.
 
     Each coordinate has a flag attached to it, most commonly seen are "A" or
     "W" that specifies if a station has been constrained (W) or not (A) in
@@ -106,12 +107,18 @@ class BerneseCrdDataSource(DataSource):
 
     type: Literal["bernese_crd"] = "bernese_crd"
     filename: os.PathLike | str
-    stddev: float = 0.0
-    weight: float = 1.0
     discard_flags: list[str] | None = None
 
-    def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
+    def __init__(
+        self,
+        sx: float = 0.0,
+        sy: float = 0.0,
+        sz: float = 0.0,
+        w: float = 1.0,
+        **kwargs,
+    ) -> None:
+        # sx, sy, sz and w are all defined in DataSource
+        super().__init__(sx=sx, sy=sy, sz=sz, w=w, **kwargs)
 
         # The overall structure of a CRD-file is:
         #
@@ -121,9 +128,9 @@ class BerneseCrdDataSource(DataSource):
         #
         # There is seemingly no fixed structure to these files. The header can differ
         # slightly from file to file. The coordinate table is made up of somewhere
-        # between 6 and 8 columns. The footer is not always present. In the code
-        # trys it's best to parse the available information without imposing a too
-        # strict understanding of the file's structure.
+        # between 6 and 8 columns. The footer is not always present. The code trys
+        # it's best to parse the available information without imposing a too strict
+        # understanding of the file's structure.
         with open(self.filename, "r", encoding="utf-8") as crdfile:
             lines = crdfile.readlines()
 
@@ -161,9 +168,9 @@ class BerneseCrdDataSource(DataSource):
                     x=crd_coord.x,
                     y=crd_coord.y,
                     z=crd_coord.z,
-                    sx=1.0,
-                    sy=1.0,
-                    sz=1.0,
-                    w=1.0,
+                    sx=sx,
+                    sy=sy,
+                    sz=sz,
+                    w=w,
                 )
             )

--- a/src/transformo/datatypes.py
+++ b/src/transformo/datatypes.py
@@ -11,7 +11,7 @@ from pydantic.dataclasses import dataclass
 from transformo._typing import ParameterValue
 
 
-@dataclass(frozen=True)
+@dataclass()
 class Coordinate:  # pylint: disable=too-many-instance-attributes
     """Containter for coordinates"""
 

--- a/test/datasources/test_datasource.py
+++ b/test/datasources/test_datasource.py
@@ -153,3 +153,60 @@ def test_datasource_hash(files) -> None:
     csv2 = CsvDataSource(filename=files["dk_cors_etrs89.csv"])
 
     assert hash(csv1) != hash(csv2)
+
+
+def test_post_init_datasource_wide_overrides(coordinate_factory) -> None:
+    """
+    Test overrides that work on the entire datasource.
+    """
+    n = 2
+    sx = 0.05
+    sy = 0.12
+    sz = 0.52
+    w = 0.7
+    t = 2099.99
+
+    coordinates = [coordinate_factory() for _ in range(n)]
+    ds = DataSource(
+        name="test",
+        coordinates=coordinates,
+        sx=sx,
+        sy=sy,
+        sz=sz,
+        w=w,
+        t=t,
+    )
+
+    for c in ds.coordinates:
+        assert c.sx == sx
+        assert c.sy == sy
+        assert c.sz == sz
+        assert c.w == c.w
+        assert c.t == c.t
+
+
+def test_post_init_datasource_wide_overrides_childs(files) -> None:
+    """
+    Test that overrides work for childs of DataSource.
+    """
+    sx = 0.05
+    sy = 0.12
+    sz = 0.52
+    w = 0.7
+    t = 2099.99
+
+    ds = CsvDataSource(
+        filename=files["dk_cors_etrs89.csv"],
+        sx=sx,
+        sy=sy,
+        sz=sz,
+        w=w,
+        t=t,
+    )
+
+    for c in ds.coordinates:
+        assert c.sx == sx
+        assert c.sy == sy
+        assert c.sz == sz
+        assert c.w == c.w
+        assert c.t == c.t

--- a/test/datasources/test_datasource.py
+++ b/test/datasources/test_datasource.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 from transformo._typing import CoordinateMatrix
+from transformo.core import CoordinateOverrides
 from transformo.datasources import CombinedDataSource, CsvDataSource, DataSource
 
 
@@ -210,3 +211,30 @@ def test_post_init_datasource_wide_overrides_childs(files) -> None:
         assert c.sz == sz
         assert c.w == c.w
         assert c.t == c.t
+
+
+def test_station_overrides(files) -> None:
+    """Test that overriding values for certain station works."""
+    ds = CsvDataSource(
+        filename=files["dk_cors_etrs89.csv"],
+        overrides={
+            "BUDP": CoordinateOverrides(sx=0.01, w=2.0),
+            "FYHA": CoordinateOverrides(sy=0.5, t=2099.0),
+            "HIRS": CoordinateOverrides(x=0.0, y=0.0, z=0.0),
+            "SULD": CoordinateOverrides(station="MULD", sz=0.42),
+        },
+    )
+
+    for c in ds.coordinates:
+        if c.station == "BUDP":
+            assert c.sx == 0.01 and c.w == 2.0
+
+        if c.station == "FYHA":
+            assert c.sy == 0.5 and c.t == 2099.0
+
+        if c.station == "HIRS":
+            assert c.x == 0.0 and c.y == 0.0 and c.z == 0.0
+
+        if c.station == "SULD":
+            assert c.sz == 0.42
+            assert c.station == "MULD"


### PR DESCRIPTION
Adds the option to change information in a datasource. This can be done both on a datasource-wide level or station by station.