### PR TITLE
Ensure geodetic coordinates in GeoJSON output

### DIFF
--- a/examples/bells_and_whistles.yaml
+++ b/examples/bells_and_whistles.yaml
@@ -23,6 +23,8 @@ presenters:
   name: PROJ String
 - type: residual_presenter
   name: Coordinate differences
+  coordinate_type: cartesian
+  geojson_file: residuals.geojson
 - type: topocentricresidual_presenter
   name: ENU Residuals
   coordinate_type: cartesian

--- a/src/transformo/core.py
+++ b/src/transformo/core.py
@@ -11,9 +11,8 @@ from typing import TYPE_CHECKING, Any, Iterable, Literal
 
 import numpy as np
 import pydantic
-import pyproj
 
-from transformo._typing import CoordinateMatrix, Vector
+from transformo._typing import CoordinateMatrix
 from transformo.datatypes import Coordinate, Parameter
 
 
@@ -605,54 +604,3 @@ class Presenter(pydantic.BaseModel):
             return self.name
 
         return self.type
-
-
-class Transformer:
-    """
-    Transform coordinates using PROJ.
-
-    Interface for pyproj that works using Transformo's datatypes such
-    as CoordinateMatrix and Vector.
-    """
-
-    def __init__(self, transformer: pyproj.Transformer | None = None):
-        """
-        Initialize a Transformer.
-
-        If None is passed to the method a generic "noop" PROJ transformation
-        is created.
-
-        Generally advised to instantiate `Transformer`s using class methods
-        such as `from_projstring`.
-        """
-        if not transformer:
-            self.transformer = pyproj.Transformer.from_pipeline("+proj=noop")
-        else:
-            self.transformer = transformer
-
-    @classmethod
-    def from_projstring(cls, projstring: str):
-        """
-        Instantiate a `Transformer` using a PROJ string.
-
-        Any valid PROJ string can be used.
-        """
-        transformer = pyproj.Transformer.from_pipeline(projstring)
-        return Transformer(transformer=transformer)
-
-    def transform_many(self, coordinates: CoordinateMatrix) -> CoordinateMatrix:
-        """
-        Transform a CoordinateMatrix.
-        """
-        results = self.transformer.itransform(coordinates)
-        return np.array(list(results))
-
-    def transform_one(self, coordinate: Vector) -> Vector:
-        """
-        Transform a single coordinate.
-        """
-        (x, y, z) = self.transformer.transform(
-            xx=coordinate[0], yy=coordinate[1], zz=coordinate[2]
-        )
-
-        return np.array((x, y, z))

--- a/src/transformo/datatypes.py
+++ b/src/transformo/datatypes.py
@@ -9,6 +9,7 @@ import pydantic
 from pydantic.dataclasses import dataclass
 
 from transformo._typing import ParameterValue
+from transformo.transformer import Transformer
 
 
 @dataclass()
@@ -95,13 +96,20 @@ class Coordinate:  # pylint: disable=too-many-instance-attributes
 
         return np.multiply(weights, self.w)
 
-    def geojson_feature(self, properties: dict | None = None) -> dict:
+    def geojson_feature(
+        self, properties: dict | None = None, transformer: Transformer | None = None
+    ) -> dict:
         """
         Return a basic GeoJSON feature.
 
         The feature is composed of the station coordinates and name. Additional
         properties can be added by supplying them in the `properties` dict.
         """
+
+        lon, lat, h = self.x, self.y, self.z
+        if transformer:
+            lon, lat, h = transformer.transform_one(np.array([lon, lat, h]))
+
         feat: dict = {
             "type": "Feature",
             "properties": {
@@ -110,8 +118,8 @@ class Coordinate:  # pylint: disable=too-many-instance-attributes
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    self.x,
-                    self.y,
+                    lon,
+                    lat,
                 ],
             },
         }

--- a/src/transformo/presenters/coordinates.py
+++ b/src/transformo/presenters/coordinates.py
@@ -11,9 +11,8 @@ from typing import Literal
 
 import numpy as np
 
-from transformo._typing import CoordinateMatrix
-from transformo.core import DataSource, Operator, Presenter, Transformer
-from transformo.datatypes import Coordinate
+from transformo.core import DataSource, Operator, Presenter
+from transformo.transformer import Transformer
 
 from . import construct_markdown_table
 
@@ -28,6 +27,16 @@ def _raise_exception_if_file_cant_be_created(filename: pathlib.Path):
     finally:
         if filename.exists():
             filename.unlink()
+
+
+class CoordinateType(Enum):
+    """
+    Defines coordinate archetypes.
+    """
+
+    CARTESIAN = "cartesian"
+    DEGREES = "degrees"
+    PROJECTED = "projected"
 
 
 class CoordinatePresenter(Presenter):
@@ -165,18 +174,26 @@ class ResidualPresenter(Presenter):
     """
 
     type: Literal["residual_presenter"] = "residual_presenter"
+
+    coordinate_type: CoordinateType
     json_file: pathlib.Path | None = None
     geojson_file: pathlib.Path | None = None
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, coordinate_type: CoordinateType, **kwargs) -> None:
         """."""
-        super().__init__(**kwargs)
+        super().__init__(coordinate_type=coordinate_type, **kwargs)
 
         if self.json_file:
             _raise_exception_if_file_cant_be_created(self.json_file)
         if self.geojson_file:
             _raise_exception_if_file_cant_be_created(self.geojson_file)
             self._geojson_features: list[dict] = []
+
+        # set up degrees -> cartesian converter
+        self._cart_transformer = Transformer.from_projstring("+proj=cart +ellps=GRS80")
+        self._cart_transformer_inv = Transformer.from_projstring(
+            "+proj=cart +ellps=GRS80 +inv"
+        )
 
         self._data: dict = {}
 
@@ -211,8 +228,14 @@ class ResidualPresenter(Presenter):
         ]
 
         if self.geojson_file:
+            transformer = None
+            if self.coordinate_type == CoordinateType.CARTESIAN:
+                transformer = self._cart_transformer_inv
+
             for coordinate in target_data.coordinates:
-                self._geojson_features.append(coordinate.geojson_feature())
+                self._geojson_features.append(
+                    coordinate.geojson_feature(transformer=transformer)
+                )
 
     def as_json(self) -> str:
         return json.dumps(self._data)
@@ -279,16 +302,6 @@ class ResidualPresenter(Presenter):
         return text
 
 
-class CoordinateType(Enum):
-    """
-    Defines coordinate archetypes.
-    """
-
-    CARTESIAN = "cartesian"
-    DEGREES = "degrees"
-    PROJECTED = "projected"
-
-
 class TopocentricResidualPresenter(Presenter):
     """
     Determine topocentric residuals between transformed and target coordinates.
@@ -304,8 +317,6 @@ class TopocentricResidualPresenter(Presenter):
 
     Projected coordinates are assumed to already be somewhat topocentric, and
     will not be manipulated before the residuals are calculated.
-
-    Degrees ...
     """
 
     type: Literal["topocentricresidual_presenter"] = "topocentricresidual_presenter"
@@ -328,6 +339,9 @@ class TopocentricResidualPresenter(Presenter):
 
         # set up degrees -> cartesian converter
         self._cart_transformer = Transformer.from_projstring("+proj=cart +ellps=GRS80")
+        self._cart_transformer_inv = Transformer.from_projstring(
+            "+proj=cart +ellps=GRS80 +inv"
+        )
 
     def evaluate(
         self,
@@ -388,8 +402,14 @@ class TopocentricResidualPresenter(Presenter):
         )
 
         if self.geojson_file:
+            transformer = None
+            if self.coordinate_type == CoordinateType.CARTESIAN:
+                transformer = self._cart_transformer_inv
+
             for coordinate in target_data.coordinates:
-                self._geojson_features.append(coordinate.geojson_feature())
+                self._geojson_features.append(
+                    coordinate.geojson_feature(transformer=transformer)
+                )
 
     def as_json(self) -> str:
         return json.dumps(self._data)
@@ -423,7 +443,7 @@ class TopocentricResidualPresenter(Presenter):
             "type": "FeatureCollection",
             "features": self._geojson_features,
         }
-        print(geojson)
+
         with open(self.geojson_file, "w", encoding="utf-8") as f:
             json.dump(geojson, f)
 

--- a/src/transformo/presenters/coordinates.py
+++ b/src/transformo/presenters/coordinates.py
@@ -213,6 +213,10 @@ class ResidualPresenter(Presenter):
         model = results[-1].coordinate_matrix
 
         residuals = np.subtract(target, model)
+
+        # convert to milimeters
+        residuals *= 1000
+
         residual_norms = [np.linalg.norm(r) for r in residuals]
 
         self._data["residuals"] = {}

--- a/src/transformo/transformer.py
+++ b/src/transformo/transformer.py
@@ -1,0 +1,61 @@
+"""
+Wrapper for pyproj, that fits the patterns of Transformo.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pyproj
+
+from transformo._typing import CoordinateMatrix, Vector
+
+
+class Transformer:
+    """
+    Transform coordinates using PROJ.
+
+    Interface for pyproj that works using Transformo's datatypes such
+    as CoordinateMatrix and Vector.
+    """
+
+    def __init__(self, transformer: pyproj.Transformer | None = None):
+        """
+        Initialize a Transformer.
+
+        If None is passed to the method a generic "noop" PROJ transformation
+        is created.
+
+        Generally advised to instantiate `Transformer`s using class methods
+        such as `from_projstring`.
+        """
+        if not transformer:
+            self.transformer = pyproj.Transformer.from_pipeline("+proj=noop")
+        else:
+            self.transformer = transformer
+
+    @classmethod
+    def from_projstring(cls, projstring: str):
+        """
+        Instantiate a `Transformer` using a PROJ string.
+
+        Any valid PROJ string can be used.
+        """
+        transformer = pyproj.Transformer.from_pipeline(projstring)
+        return Transformer(transformer=transformer)
+
+    def transform_many(self, coordinates: CoordinateMatrix) -> CoordinateMatrix:
+        """
+        Transform a CoordinateMatrix.
+        """
+        results = self.transformer.itransform(coordinates)
+        return np.array(list(results))
+
+    def transform_one(self, coordinate: Vector) -> Vector:
+        """
+        Transform a single coordinate.
+        """
+        (x, y, z) = self.transformer.transform(
+            xx=coordinate[0], yy=coordinate[1], zz=coordinate[2]
+        )
+
+        return np.array((x, y, z))

--- a/test/presenters/test_coordinates.py
+++ b/test/presenters/test_coordinates.py
@@ -172,8 +172,8 @@ def test_residual_presenter(tmp_path, dummy_operator):
 
     data = json.loads(presenter.as_json())
 
-    assert data["residuals"]["A"][0] == 2.5
-    assert data["residuals"]["B"][3] == 1.0
+    assert data["residuals"]["A"][0] == 2500.0
+    assert data["residuals"]["B"][3] == 1000.0
 
     print(data)
     print(presenter.as_markdown())

--- a/test/presenters/test_coordinates.py
+++ b/test/presenters/test_coordinates.py
@@ -158,7 +158,11 @@ def test_residual_presenter(tmp_path, dummy_operator):
         ]
     )
 
-    presenter = ResidualPresenter(json_file=json_file, geojson_file=geojson_file)
+    presenter = ResidualPresenter(
+        coordinate_type=CoordinateType.DEGREES,
+        json_file=json_file,
+        geojson_file=geojson_file,
+    )
     presenter.evaluate(
         operators=[dummy_operator],
         source_data=model,

--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -7,6 +7,7 @@ import pydantic
 import pytest
 
 from transformo.datatypes import Coordinate, Parameter
+from transformo.transformer import Transformer
 
 
 def test_coordinate_field_limits():
@@ -164,6 +165,17 @@ def test_coordinate_geojson_feature(coordinate: Coordinate):
 
     # verify that origin properties are overriden by those in `properties`
     assert feature_with_properties["properties"]["station"] == "STATION"
+
+    # test that the transformer works on the output coordinates
+    transformer = Transformer.from_projstring("+proj=helmert +x=1.0 +y=2.0")
+    feature_transformed_coords = coordinate.geojson_feature(transformer=transformer)
+
+    assert (
+        feature_transformed_coords["geometry"]["coordinates"][0] == coordinate.x + 1.0
+    )
+    assert (
+        feature_transformed_coords["geometry"]["coordinates"][1] == coordinate.y + 2.0
+    )
 
 
 def test_parameter():

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 
-from transformo.core import Transformer
+from transformo.transformer import Transformer
 
 
 def test_initialization() -> None:


### PR DESCRIPTION
Coordinate.geojson_feature() now takes a transformer, so that it can
change the coordinate into geodetic coordinates. It is the
responsibility of the caller to give a suitable transformer.

This commits fixes problems in presenters that produces GeoJSON files.
As a consequence it is now mandatory to set `coordinate_type` for the
residual_presenter.